### PR TITLE
i12 - Simplify BWM in ari4

### DIFF
--- a/ari4.py
+++ b/ari4.py
@@ -4,7 +4,6 @@ import asyncio
 
 # import ari4 modules
 import sys
-
 sys.path.insert(0, 'modules')
 import logmgr
 import mememgr
@@ -12,7 +11,6 @@ import bannedwordsmgr
 
 # regexes
 client = discord.Client()
-
 
 @client.event
 async def on_message(message):
@@ -60,6 +58,5 @@ async def on_ready():
     print(client.user.name)
     print(client.user.id)
     print('------')
-
 
 client.run(maricon.key)

--- a/ari4.py
+++ b/ari4.py
@@ -32,25 +32,13 @@ async def on_message(message):
         await client.send_message(message.channel, who)
 
     # BannedWordsMgr
-
-    bwadmin = bannedwordsmgr.bwadmin(message.content, str(message.author))
-    if bwadmin:
-        await client.send_message(message.channel, bwadmin)
-
-    bwcheck = bannedwordsmgr.checkword(message.content.lower())
-
-    if bwcheck:
-        if bwadmin:  # it looks stupid if you run an admin and then it deletes it so never delete any bwadmin messages
-            return
-        asyncio.sleep(2)
+    bwm = bannedwordsmgr.bwm(message.content, str(message.author))
+    if bwm[0] == 'Delete':
         await client.delete_message(message)
+    elif len(bwm) > 1:
+        for bwmx in bwm:
+            await client.send_message(message.channel, bwmx)
 
-    haspass = bannedwordsmgr.nwordcheck(message.content.lower(), str(message.author))
-
-    if haspass == False:
-        await client.delete_message(message)
-
-    bannedwordsmgr.blackcess(message.content, str(message.author))
 
 @client.event
 async def on_ready():

--- a/modules/bannedwordsmgr.py
+++ b/modules/bannedwordsmgr.py
@@ -90,10 +90,10 @@ def blackcess(message, author):
 
 def bwm(message, author):
     payload = ['DoNotDelete']
-    bwadmin(message, author)
-    #bwlist
     if message == ('!banword list'):
         payload.append('Banned Words include: ' + str(BannedWords))
+        return payload
+    bwadmin(message, author)
     blackcess(message, author)
     msgdelete = False
     if BannedWordsEnabled is True:

--- a/modules/bannedwordsmgr.py
+++ b/modules/bannedwordsmgr.py
@@ -1,8 +1,9 @@
 import adminmgr
 
-BannedWords = ["netorare"]
+BannedWords = ["netorare']
 
 BannedWordsEnabled = True
+payload=['DoNotDelete']
 
 
 def permission(author):
@@ -86,15 +87,20 @@ def blackcess(message, author):
             print(author + ' has revoked the rights of ' + removeblackcess[2])
             passpeople.remove(removeblackcess[2])
 
-
-def bwlist(message):
-    if message == ('!banword list'):
-        return BannedWords
-
-
 def bwm(message, author):
+    payload = ['DoNotDelete']
     bwadmin(message, author)
-    bwlist(message)
+    #bwlist
+    if message == ('!banword list'):
+        payload.append('Banned Words include: ' + str(BannedWords))
+    blackcess(message, author)
+    msgdelete = False
     if BannedWordsEnabled is True:
-        checkword(message)
-        nwordcheck(message, author)
+        if checkword(message) is True:
+            msgdelete = True
+        if nwordcheck(message, author) is False:
+            msgdelete = True
+    if msgdelete == True:
+        payload[0] = 'Delete'
+    return payload
+

--- a/modules/bannedwordsmgr.py
+++ b/modules/bannedwordsmgr.py
@@ -1,53 +1,67 @@
 import adminmgr
 
-BannedWords=["netorare"]
+BannedWords = ["netorare"]
+
+BannedWordsEnabled = True
 
 
-def bwadmin(message, user):
+def permission(author):
+    if adminmgr.adminCheck(author) is False:
+        return False
 
-    if message == ('!banword list'):
-        return BannedWords
+
+def bwadmin(message, author):
+    global BannedWordsEnabled
+
+    if message.startswith('!banword'):
+        if permission(author) is False:
+            return
 
     if message.startswith('!banword add'):
-        isAdmin = adminmgr.adminCheck(user)
-        if isAdmin == False:
-            return
         addword = message.split(" ")
         BannedWords.append(addword[2])
         print('BannedWordsMgr: Added ' + addword[2] + ' to banned words list.')
         return BannedWords
 
     if message.startswith('!banword remove'):
-        isAdmin = adminmgr.adminCheck(user)
-        if isAdmin == False:
-            return
         addword = message.split(" ")
         BannedWords.remove(addword[2])
         print('BannedWordsMgr: Added ' + addword[2] + ' to banned words list.')
         return BannedWords
 
-def checkword(message):
+    if message.startswith('!banword enable'):
+        BannedWordsEnabled = True
+        print('BannedWordsMgr: Enabled')
 
+    if message.startswith('!banword disable'):
+        BannedWordsEnabled = False
+        print('BannedWordsMgr: Disabled')
+
+
+def checkword(message):
     for BannedWord in BannedWords:
         if BannedWord in message:
-            print('BannedWordsMgr: deleted message with ' + BannedWord)
+            print('BannedWordsMgr: deleted message with banned phrase: ' + BannedWord)
             return True
 
     if message == ('ntr'):
         print('BannedWordsMgr: deleted ntr message')
         return True
 
-nwordvariants = ['nigga','nigger','niqqa']
+
+nwordvariants = ['nigga', 'nigger', 'niqqa']
 blackpeople = []
 passpeople = []
 
-def nwordcheck(message,author):
+
+def nwordcheck(message, author):
     for nword in nwordvariants:
         if nword in message:
             if isuserblack(author):
                 return True
             else:
                 return False
+
 
 def isuserblack(author):
     if author in blackpeople:
@@ -60,7 +74,8 @@ def isuserblack(author):
         print('BannedWordsMgr: ' + author + ' is not black, deleting message')
         return False
 
-def blackcess(message,author):
+
+def blackcess(message, author):
     if author in blackpeople:
         if message.startswith('!pass give'):
             giveblackcess = message.split(" ")
@@ -70,3 +85,16 @@ def blackcess(message,author):
             removeblackcess = message.split(" ")
             print(author + ' has revoked the rights of ' + removeblackcess[2])
             passpeople.remove(removeblackcess[2])
+
+
+def bwlist(message):
+    if message == ('!banword list'):
+        return BannedWords
+
+
+def bwm(message, author):
+    bwadmin(message, author)
+    bwlist(message)
+    if BannedWordsEnabled is True:
+        checkword(message)
+        nwordcheck(message, author)

--- a/modules/bannedwordsmgr.py
+++ b/modules/bannedwordsmgr.py
@@ -1,9 +1,8 @@
 import adminmgr
 
-BannedWords = ["netorare']
+BannedWords = ["netorare"]
 
 BannedWordsEnabled = True
-payload=['DoNotDelete']
 
 
 def permission(author):
@@ -15,6 +14,8 @@ def bwadmin(message, author):
     global BannedWordsEnabled
 
     if message.startswith('!banword'):
+        if message.startswith('!banword list'): # dont check admin for banword list
+            return
         if permission(author) is False:
             return
 
@@ -103,4 +104,3 @@ def bwm(message, author):
     if msgdelete == True:
         payload[0] = 'Delete'
     return payload
-

--- a/modules/mememgr.py
+++ b/modules/mememgr.py
@@ -8,7 +8,6 @@ def chance(x):
         print('MemeMgr: Memed with a chance of 1/' + str(x))
     else:
         chancerespond = False
-
     return chancerespond
 
 def memes(message):
@@ -35,7 +34,6 @@ def memes(message):
 
     if message == 'all my friends are dead':
         mememessages.append('push me to the edge')
-
 
     return mememessages
 

--- a/test/test.py
+++ b/test/test.py
@@ -13,3 +13,6 @@ bannedwordsmgr.bwm('!banword disable','breezyexcursion#9570')
 bannedwordsmgr.bwm('netorare','bobby')
 bannedwordsmgr.bwm('!banword enable','breezyexcursion#9570')
 bannedwordsmgr.bwm('netorare','bobby')
+
+#TEST 3 - List Banwords
+bannedwordsmgr.bwm('!banword list','whoever')

--- a/test/test.py
+++ b/test/test.py
@@ -15,4 +15,4 @@ bannedwordsmgr.bwm('!banword enable','breezyexcursion#9570')
 bannedwordsmgr.bwm('netorare','bobby')
 
 #TEST 3 - List Banwords
-bannedwordsmgr.bwm('!banword list','whoever')
+print(bannedwordsmgr.bwm('!banword list','whoever'))

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,15 @@
+import sys
+#import modules
+sys.path.insert(0, '../modules')
+import logmgr
+import mememgr
+import bannedwordsmgr
+
+#TEST 1 - Delete Banned Words
+bannedwordsmgr.bwm('netorare','bobby')
+
+#TEST 2 - Disable/Enable Function
+bannedwordsmgr.bwm('!banword disable','breezyexcursion#9570')
+bannedwordsmgr.bwm('netorare','bobby')
+bannedwordsmgr.bwm('!banword enable','breezyexcursion#9570')
+bannedwordsmgr.bwm('netorare','bobby')


### PR DESCRIPTION
Simplify BWM usage in ari4. Rather than call different functions from BWM, we call one main BWM function which handles everything else.

**Known Issues**
If you run !banword add, it will delete the message, since it runs the check after.We eventually need to fix this so it does not run the check at all while running admin messages.